### PR TITLE
set sse header

### DIFF
--- a/api/util.go
+++ b/api/util.go
@@ -30,6 +30,15 @@ func getUserID(ctx context.Context) (int32, error) {
 	return userID, nil
 }
 
+
+func setSSEHeader(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+}
+
+
 func RespondWithError(w http.ResponseWriter, code int, message string, details interface{}) {
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(ErrorResponse{Code: code, Message: message, Details: details})


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

- New Feature: Added a function to set Server-Sent Events (SSE) headers and used it in `chat_stream` and `test_replay` functions.
- New Feature: Added a new function `setSSEHeader` to set headers for Server-Sent Events (SSE) in `api/util.go`. 

These changes enable the server to send real-time updates to clients using SSE.
<!-- end of auto-generated comment: release notes by openai -->