### PR TITLE
修复数据库重新部署后，chatgpt无法使用问题。

### DIFF
--- a/api/sqlc_queries/chat_message.sql.go
+++ b/api/sqlc_queries/chat_message.sql.go
@@ -15,7 +15,7 @@ INSERT INTO chat_message (id, chat_session_uuid, uuid, role, ip, content, token_
 SELECT COALESCE(MAX(id), 0) + 1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
 FROM chat_message
 RETURNING id, uuid, chat_session_uuid, role, ip, content, llm_summary, score, user_id, created_at, updated_at, created_by, updated_by, is_deleted, is_pin, token_count, raw
-`;
+`
 
 type CreateChatMessageParams struct {
 	ChatSessionUuid string          `json:"chatSessionUuid"`

--- a/api/sqlc_queries/chat_message.sql.go
+++ b/api/sqlc_queries/chat_message.sql.go
@@ -11,10 +11,11 @@ import (
 )
 
 const createChatMessage = `-- name: CreateChatMessage :one
-INSERT INTO chat_message (chat_session_uuid, uuid, role, content, token_count, score, user_id, created_by, updated_by, llm_summary, raw)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING id, uuid, chat_session_uuid, role, content, llm_summary, score, user_id, created_at, updated_at, created_by, updated_by, is_deleted, is_pin, token_count, raw
-`
+INSERT INTO chat_message (id, chat_session_uuid, uuid, role, ip, content, token_count, score, user_id, created_by, updated_by, llm_summary, raw)
+SELECT COALESCE(MAX(id), 0) + 1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
+FROM chat_message
+RETURNING id, uuid, chat_session_uuid, role, ip, content, llm_summary, score, user_id, created_at, updated_at, created_by, updated_by, is_deleted, is_pin, token_count, raw
+`;
 
 type CreateChatMessageParams struct {
 	ChatSessionUuid string          `json:"chatSessionUuid"`

--- a/api/sqlc_queries/chat_prompt.sql.go
+++ b/api/sqlc_queries/chat_prompt.sql.go
@@ -10,10 +10,11 @@ import (
 )
 
 const createChatPrompt = `-- name: CreateChatPrompt :one
-INSERT INTO chat_prompt (uuid, chat_session_uuid, role, content, token_count, user_id, created_by, updated_by)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO chat_prompt (id, uuid, chat_session_uuid, role, content, token_count, user_id, created_by, updated_by)
+SELECT COALESCE(MAX(id), 0) + 1, $1, $2, $3, $4, $5, $6, $7, $8
+FROM chat_prompt
 RETURNING id, uuid, chat_session_uuid, role, content, score, user_id, created_at, updated_at, created_by, updated_by, is_deleted, token_count
-`
+`;
 
 type CreateChatPromptParams struct {
 	Uuid            string `json:"uuid"`


### PR DESCRIPTION
#### 问题描述

1. 当我删除了sql中的databse时，此时将数据 dump 后。我发现在存储chat信息至数据库时，报错了主键 ID 已存在。目前我发现的存在问题的表有 chat_prompt、chat_message。


#### 解决方法

该pr是我的解决方法，主要逻辑是：在插入数据时，每次使用最大的 ID。

#### 备注

这也许不是代码层面bug，我并不了解 postgres。猜测可能是因为 postgres 数据库逻辑导致。或者就是我不会用。