### PR TITLE
Fixed error in admin, config & chat  page

### DIFF
--- a/api/chat_session_service.go
+++ b/api/chat_session_service.go
@@ -90,6 +90,7 @@ func (s *ChatSessionService) GetSimpleChatSessionsByUserID(ctx context.Context, 
 			MaxTokens:   session.MaxTokens,
 			Debug:       session.Debug,
 			Model:       session.Model,
+			SummarizeMode: session.SummarizeMode,
 		}
 	})
 	return simple_sessions, nil

--- a/api/models.go
+++ b/api/models.go
@@ -78,6 +78,7 @@ type SimpleChatSession struct {
 	MaxTokens   int32   `json:"maxTokens"`
 	Debug       bool    `json:"debug"`
 	Model       string  `json:"model"`
+	SummarizeMode bool  `json:"summarizeMode"`
 }
 
 type ChatMessageResponse struct {

--- a/web/src/views/admin/index.vue
+++ b/web/src/views/admin/index.vue
@@ -4,7 +4,7 @@ import { computed, h, reactive, ref } from 'vue'
 import { NIcon, NLayout, NLayoutSider, NMenu } from 'naive-ui'
 import type { MenuOption } from 'naive-ui'
 import { PulseOutline, ShieldCheckmarkOutline } from '@vicons/ionicons5'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRoute } from 'vue-router'
 import Permission from '@/views/components/Permission.vue'
 import { t } from '@/locales'
 import { useBasicLayout } from '@/hooks/useBasicLayout'
@@ -15,11 +15,14 @@ const { isMobile } = useBasicLayout()
 
 // login modal will appear when there is no token
 const authStore = useAuthStore()
+const currentRoute = useRoute()
+const USER_ROUTE = 'AdminUser'
+const MODEL_ROUTE = 'AdminModel'
 
 const needPermission = computed(() => !authStore.token) // || (!!authStore.token && authStore.expiresIn < Date.now() / 1000))
 
 const collapsed: Ref<boolean> = ref(true)
-const activeKey: Ref<string> = ref('rateLimit')
+const activeKey = ref(currentRoute.name?.toString())
 
 const getMobileClass = computed<CSSProperties>(() => {
   if (isMobile.value) {
@@ -43,12 +46,12 @@ const menuOptions: MenuOption[] = reactive([
           RouterLink,
           {
             to: {
-              name: 'AdminUser',
+              name: USER_ROUTE,
             },
           },
           { default: () => t('admin.rateLimit') },
         ),
-    key: 'rateLimit',
+    key: USER_ROUTE,
     icon: renderIcon(PulseOutline),
   },
   {
@@ -56,12 +59,12 @@ const menuOptions: MenuOption[] = reactive([
       RouterLink,
       {
         to: {
-          name: 'AdminModel',
+          name: MODEL_ROUTE,
         },
       },
       { default: () => t('admin.model') },
     ),
-    key: 'model',
+    key: MODEL_ROUTE,
     icon: renderIcon(ShieldCheckmarkOutline),
   },
 ])
@@ -88,7 +91,7 @@ function handleUpdateCollapsed() {
                 <SvgIcon v-else class="text-2xl" icon="ri:align-right" />
               </button>
             </div>
-            <h1  v-if="!isMobile" class="flex-1 px-4 pr-6 overflow-hidden cursor-pointer select-none text-ellipsis whitespace-nowrap">
+            <h1 v-if="!isMobile" class="flex-1 px-4 pr-6 overflow-hidden cursor-pointer select-none text-ellipsis whitespace-nowrap">
               Admin
             </h1>
             <!-- <div class="flex items-center space-x-2">
@@ -112,7 +115,7 @@ function handleUpdateCollapsed() {
             :style="getMobileClass" @collapse="collapsed = true" @expand="collapsed = false"
           >
             <NMenu
-              v-model:value="activeKey" :collapsed="collapsed" :collapsed-width="64" :collapsed-icon-size="22"
+              v-model:value="activeKey" :collapsed="collapsed" :collapsed-width="64" :collapsed-icon-size="22" @update:value="handleUpdateCollapsed"
               :options="menuOptions"
             />
           </NLayoutSider>

--- a/web/src/views/admin/model/index.vue
+++ b/web/src/views/admin/model/index.vue
@@ -3,6 +3,7 @@ import { NTabPane, NTabs } from 'naive-ui'
 import { ref } from 'vue'
 import PerModelRatelimit from './per_mode_ratelimit/index.vue'
 import SystemModel from './system_model/index.vue'
+import { SvgIcon } from '@/components/common'
 const active = ref('System')
 </script>
 

--- a/web/src/views/admin/model/per_mode_ratelimit/index.vue
+++ b/web/src/views/admin/model/per_mode_ratelimit/index.vue
@@ -60,7 +60,7 @@ function createColumns(): DataTableColumns<RowData> {
     width: 250,
     render(row: RowData, index: number) {
       return h(NInput, {
-        value: row.rateLimit,
+        value: row.rateLimit.toString(),
         onUpdateValue(v: string) {
           // assuming that `data` is an array of FormData objects
           data.value[index].rateLimit = v

--- a/web/src/views/admin/model/system_model/index.vue
+++ b/web/src/views/admin/model/system_model/index.vue
@@ -119,7 +119,7 @@ function createColumns(): DataTableColumns<Chat.ChatModel> {
     width: 100,
     render(row: Chat.ChatModel, index: number) {
       return h(NInput, {
-        value: row.orderNumber,
+        value: row.orderNumber?.toString(),
         width: 5,
         onUpdateValue(v: string) {
           // Assuming `data` is an array of FormData objects
@@ -136,7 +136,7 @@ function createColumns(): DataTableColumns<Chat.ChatModel> {
     width: 100,
     render(row: Chat.ChatModel, index: number) {
       return h(NInput, {
-        value: row.defaultToken,
+        value: row.defaultToken?.toString(),
         width: 5,
         onUpdateValue(v: string) {
           // Assuming `data` is an array of FormData objects
@@ -153,7 +153,7 @@ function createColumns(): DataTableColumns<Chat.ChatModel> {
     width: 100,
     render(row: Chat.ChatModel, index: number) {
       return h(NInput, {
-        value: row.maxToken,
+        value: row.maxToken?.toString(),
         width: 5,
         onUpdateValue(v: string) {
           // Assuming `data` is an array of FormData objects

--- a/web/src/views/admin/user/index.vue
+++ b/web/src/views/admin/user/index.vue
@@ -99,7 +99,7 @@ const columns = [
     width: 100,
     render: (row: any, index: number) => {
       return h(NInput, {
-        value: row.rateLimit,
+        value: row.rateLimit.toString(),
         width: 50,
         async onUpdateValue(v: string) {
           try {

--- a/web/src/views/chat/components/Session/SessionConfig.vue
+++ b/web/src/views/chat/components/Session/SessionConfig.vue
@@ -67,6 +67,7 @@ const debouneUpdate = debounce(async (model: ModelType) => {
     n: model.n,
     debug: model.debug,
     model: model.chatModel,
+    summarizeMode: model.summarizeMode,
   })
 }, 200)
 

--- a/web/src/views/chat/index.vue
+++ b/web/src/views/chat/index.vue
@@ -190,6 +190,7 @@ async function onConversationStream() {
                     loading: false,
                   },
                 )
+                scrollToBottom()
               }
               catch (error) {
                 // eslint-disable-next-line no-console
@@ -537,7 +538,7 @@ function getDataFromResponseText(responseText: string): string {
           </template>
           <template v-else>
             <div>
-              <Message v-for="(item, index) of dataSources" :key="index"  :date-time="item.dateTime"
+              <Message v-for="(item, index) of dataSources" :key="index" :date-time="item.dateTime"
                 :model="chatSession?.model" :text="item.text" :inversion="item.inversion" :error="item.error"
                 :is-prompt="item.isPrompt" :is-pin="item.isPin" :loading="item.loading" :pining="pining" :index="index"
                 @regenerate="onRegenerate(index)" @delete="handleDelete(index)" @toggle-pin="handleTogglePin(index)"


### PR DESCRIPTION
admin page
修复：
1、number类型转成string的控制台警告。
2、AdminModel界面tab图标无法展示。
3、在AdminModel界面刷新后菜单栏默认选中AdminUser的选项。
4、菜单栏选择选项后不会隐藏。
session config page
修复总结模式开关无法同步状态。
chat page
修复信息超出画面时不会自动滑到底部。