### PR TITLE
Fixed refresh chat page error and delete chatseesion error

### DIFF
--- a/web/src/store/modules/chat/helper.ts
+++ b/web/src/store/modules/chat/helper.ts
@@ -16,3 +16,13 @@ export function getLocalState(): Chat.ChatState {
 export function setLocalState(state: Chat.ChatState) {
   ss.set(LOCAL_NAME, state)
 }
+
+export function check_chat(chat: Chat.ChatState['chat'], need_length = true) {
+  const keys = Object.keys(chat)
+  const data: [Array<string>, number?] = [keys]
+  if (need_length) {
+    const keys_length = keys.length
+    data.push(keys_length)
+  }
+  return data
+}

--- a/web/src/store/modules/chat/helper.ts
+++ b/web/src/store/modules/chat/helper.ts
@@ -2,13 +2,15 @@ import { ss } from '@/utils/storage'
 
 const LOCAL_NAME = 'chatStorage'
 
+const default_chat_data: Chat.ChatState = {
+  active: null,
+  history: [],
+  chat: {},
+}
+
 export function getLocalState(): Chat.ChatState {
   const localState = ss.get(LOCAL_NAME)
-  return localState ?? {
-    active: null,
-    history: [],
-    chat: [],
-  }
+  return localState ?? default_chat_data
 }
 
 export function setLocalState(state: Chat.ChatState) {

--- a/web/src/store/modules/chat/index.ts
+++ b/web/src/store/modules/chat/index.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { v4 as uuidv4 } from 'uuid'
 
-import { getLocalState, setLocalState } from './helper'
+import { check_chat, getLocalState, setLocalState } from './helper'
 import { router } from '@/router'
 import {
   clearSessionChatMessages,
@@ -123,23 +123,20 @@ export const useChatStore = defineStore('chat-store', {
 
       if (index > 0 && index <= this.history.length) {
         const uuid = this.history[index - 1].uuid
-        this.active = uuid
-        this.reloadRoute(uuid)
+        this.setActive(uuid)
         return
       }
 
       if (index === 0) {
         if (this.history.length > 0) {
           const uuid = this.history[0].uuid
-          this.active = uuid
-          this.reloadRoute(uuid)
+          this.setActive(uuid)
         }
       }
 
       if (index > this.history.length) {
         const uuid = this.history[this.history.length - 1].uuid
-        this.active = uuid
-        this.reloadRoute(uuid)
+        this.setActive(uuid)
       }
     },
 
@@ -150,9 +147,9 @@ export const useChatStore = defineStore('chat-store', {
     },
 
     getChatByUuidAndIndex(uuid: string, index: number) {
-      const keys = Object.keys(this.chat)
+      const [keys, keys_length] = check_chat(this.chat)
       if (!uuid) {
-        if (keys.length)
+        if (keys_length)
           return this.chat[uuid][index]
         return null
       }
@@ -164,7 +161,7 @@ export const useChatStore = defineStore('chat-store', {
 
     async addChatByUuid(uuid: string, chat: Chat.Message) {
       const new_chat_text = t('chat.new')
-      const keys = Object.keys(this.chat)
+      const [keys] = check_chat(this.chat, false)
       if (!uuid) {
         if (this.history.length === 0) {
           const uuid = uuidv4()
@@ -206,9 +203,9 @@ export const useChatStore = defineStore('chat-store', {
 
     async updateChatByUuid(uuid: string, index: number, chat: Chat.Message) {
       // TODO: sync with server
-      const keys = Object.keys(this.chat)
+      const [keys, keys_length] = check_chat(this.chat)
       if (!uuid) {
-        if (keys.length) {
+        if (keys_length) {
           this.chat[keys[0]][index] = chat
           this.recordState()
         }
@@ -227,9 +224,9 @@ export const useChatStore = defineStore('chat-store', {
       index: number,
       chat: Partial<Chat.Message>,
     ) {
-      const keys = Object.keys(this.chat)
+      const [keys, keys_length] = check_chat(this.chat)
       if (!uuid) {
-        if (keys.length) {
+        if (keys_length) {
           this.chat[keys[0]][index] = { ...this.chat[keys[0]][index], ...chat }
           this.recordState()
         }
@@ -247,9 +244,9 @@ export const useChatStore = defineStore('chat-store', {
     },
 
     async deleteChatByUuid(uuid: string, index: number) {
-      const keys = Object.keys(this.chat)
+      const [keys, keys_length] = check_chat(this.chat)
       if (!uuid) {
-        if (keys.length) {
+        if (keys_length) {
           const chatData = this.chat[keys[0]]
           const chat = chatData[index]
           chatData.splice(index, 1)
@@ -273,9 +270,9 @@ export const useChatStore = defineStore('chat-store', {
 
     clearChatByUuid(uuid: string) {
       // does this every happen?
-      const keys = Object.keys(this.chat)
+      const [keys, keys_length] = check_chat(this.chat)
       if (!uuid) {
-        if (keys.length) {
+        if (keys_length) {
           this.chat[keys[0]] = []
           this.recordState()
         }

--- a/web/src/store/modules/chat/index.ts
+++ b/web/src/store/modules/chat/index.ts
@@ -46,9 +46,9 @@ export const useChatStore = defineStore('chat-store', {
       return (uuid?: string) => {
         if (uuid)
           return state.chat[uuid] ?? []
-        return (
-          state.chat[state.active] ?? []
-        )
+        if (state.active)
+          return state.chat[state.active] ?? []
+        return []
       }
     },
   },

--- a/web/src/typings/chat.d.ts
+++ b/web/src/typings/chat.d.ts
@@ -28,7 +28,7 @@ declare namespace Chat {
 	interface ChatState {
 		active: string | null
 		history: Session[]
-		chat: { uuid: string; data: Message[] }[]
+		chat: { [uuid: string]: Message[] }
 	}
 
 	interface ConversationRequest {

--- a/web/src/views/chat/index.vue
+++ b/web/src/views/chat/index.vue
@@ -37,8 +37,9 @@ const { scrollRef, scrollToBottom } = useScroll()
 // session uuid
 const { uuid } = route.params as { uuid: string }
 const sessionUuid = uuid
+chatStore.syncChatMessages(sessionUuid)
 const dataSources = computed(() => chatStore.getChatSessionDataByUuid(sessionUuid))
-const chatSession = computed(() => chatStore.getChatSessionByUuid(uuid))
+const chatSession = computed(() => chatStore.getChatSessionByUuid(sessionUuid))
 
 const prompt = ref<string>('')
 const loading = ref<boolean>(false)


### PR DESCRIPTION
chat page
1、修复刷新页面时无法自动滑到最后一条信息
原因：之前是列表形式存问答信息数据，在 chat 页面挂载完滑到最后一条信息，syncChatSessions这个方法又重新刷新了chat的信息，导致变回第一条信息位置
解决：把列表改成字典存问答信息数据，格式：{ "uuidxx": [{}, {}] } ，不用先清空数据导致触发数据更新，把同步信息方法移到 chat 页面触发，每次只同步当前页面的信息
2、修复删除 session 后刷新页面请求数据库active用的还是已被删除的 session_id
