### PR TITLE
Add "Add Model" localization and copy functionality to model table

### DIFF
--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1,6 +1,7 @@
 {
     "admin": {
         "add_user_model_rate_limit": "Add User Session Count",
+        "add_model": "Add Model",
         "chat_model": {
             "actions": "Actions",
             "apiAuthHeader": "Auth Header key",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -130,9 +130,11 @@
     "system_model_tab_title": "模型配置",
     "per_model_rate_limit_title": "模型流控",
     "add_user_model_rate_limit": "添加用户会话数量",
+    "add_model": "添加模型",  
     "rate_limit": "会话数量(10min)",
     "chat_model_name": "模型ID",
     "chat_model": {
+      "copy_success": "复制成功",
       "deleteModel": "删除",
       "deleteModelConfirm": "确认删除",
       "name": "模型ID",

--- a/web/src/locales/zh-TW.json
+++ b/web/src/locales/zh-TW.json
@@ -1,6 +1,7 @@
 {
     "admin": {
         "add_user_model_rate_limit": "添加用戶會話數量",
+        "add_model": "添加模型",
         "chat_model": {
             "actions": "操作",
             "apiAuthHeader": "Auth Header 鍵",

--- a/web/src/views/admin/model/AddModelForm.vue
+++ b/web/src/views/admin/model/AddModelForm.vue
@@ -42,11 +42,11 @@ async function addRow() {
 <template>
   <div>
     <NForm :model="formData">
-      <NFormItem path="label" :label="$t('admin.chat_model.label')">
-        <NInput v-model:value="formData.label" />
-      </NFormItem>
       <NFormItem path="name" :label="$t('admin.chat_model.name')">
         <NInput v-model:value="formData.name" />
+      </NFormItem>
+      <NFormItem path="label" :label="$t('admin.chat_model.label')">
+        <NInput v-model:value="formData.label" />
       </NFormItem>
       <NFormItem path="url" :label="$t('admin.chat_model.url')">
         <NInput v-model:value="formData.url" />

--- a/web/src/views/admin/model/index.vue
+++ b/web/src/views/admin/model/index.vue
@@ -247,24 +247,43 @@ function createColumns(): DataTableColumns<Chat.ChatModel> {
   const actionField = {
     title: t('admin.chat_model.actions'),
     key: 'actions',
+    width: 100,
     render(row: any) {
-      return h(
+      return h('div', { class: 'flex' }, [
+      h(
         HoverButton,
         {
-          tooltip: 'Delete',
-          onClick: () => deleteRow(row),
+        tooltip: 'Delete',
+        onClick: () => deleteRow(row),
         },
         {
-          default: () => {
-            return h(SvgIcon, {
-              class: 'text-xl',
-              icon: 'material-symbols:delete',
-            })
-          },
+        default: () => {
+          return h(SvgIcon, {
+          class: 'text-xl',
+          icon: 'material-symbols:delete',
+          })
         },
-      )
+        },
+      ),
+      h(
+        HoverButton,
+        {
+        tooltip: 'Copy',
+        onClick: () => copyRow(row),
+        },
+        {
+        default: () => {
+          return h(SvgIcon, {
+          class: 'text-xl',
+          icon: 'material-symbols:content-copy-outline-rounded',
+          })
+        },
+        },
+      ),
+      ])
     },
-  }
+    }
+
 
   return ([
     nameField,
@@ -300,6 +319,13 @@ async function deleteRow(row: any) {
   })
 }
 
+async function copyRow(row: any) {
+  // copy to clipboard
+  const text = JSON.stringify(row)
+  navigator.clipboard.writeText(text);
+  ms_ui.success(t('admin.chat_model.copy_success'))
+}
+
 function checkNoRowIsDefaultTrue(v: boolean) {
   if (v === false)
     return
@@ -324,7 +350,7 @@ function checkNoRowIsDefaultTrue(v: boolean) {
   <div class="m-5" v-if="!isLoading">
     <NDataTable :columns="columns" :data="data" :loading="isLoading" />
   </div>
-  <NModal v-model:show="dialogVisible" :title="$t('admin.add_user_model_rate_limit')" preset="dialog">
+  <NModal v-model:show="dialogVisible" :title="$t('admin.add_model')" preset="dialog">
     <AddModelForm @new-row-added="newRowEventHandle" />
   </NModal>
 </template>


### PR DESCRIPTION
- Added "Add Model" translations to `en-US`, `zh-CN`, and `zh-TW` locale files.
- Reordered form fields in `AddModelForm.vue` for consistency.
- Added copy functionality to the model table in `index.vue`, including a success message and updated UI layout.
- Updated modal title to use the new "Add Model" translation.