### PR TITLE
Refactor chat model handling and move Ollama streaming logic to separ…

### DIFF
--- a/api/model_ollama_service.go
+++ b/api/model_ollama_service.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/swuecho/chat_backend/models"
+	"github.com/swuecho/chat_backend/sqlc_queries"
+)
+
+// Ollama ChatModel implementation
+type OllamaChatModel struct {
+	h *ChatHandler
+}
+
+func (m *OllamaChatModel) Stream(w http.ResponseWriter, chatSession sqlc_queries.ChatSession, chat_compeletion_messages []models.Message, chatUuid string, regenerate bool, stream bool) (*models.LLMAnswer, error) {
+	return m.h.chatOllamStream(w, chatSession, chat_compeletion_messages, chatUuid, regenerate)
+}
+
+func (h *ChatHandler) chatOllamStream(w http.ResponseWriter, chatSession sqlc_queries.ChatSession, chat_compeletion_messages []models.Message, chatUuid string, regenerate bool) (*models.LLMAnswer, error) {
+	// set the api key
+	chatModel, err := h.service.q.ChatModelByName(context.Background(), chatSession.Model)
+	if err != nil {
+		RespondWithAPIError(w, ErrResourceNotFound("chat model: "+chatSession.Model))
+		return nil, err
+	}
+	jsonData := map[string]interface{}{
+		"model":    strings.Replace(chatSession.Model, "ollama-", "", 1),
+		"messages": chat_compeletion_messages,
+	}
+	// convert data to json format
+	jsonValue, _ := json.Marshal(jsonData)
+	// create the request
+	req, err := http.NewRequest("POST", chatModel.Url, bytes.NewBuffer(jsonValue))
+
+	if err != nil {
+		RespondWithAPIError(w, ErrInternalUnexpected.WithDetail("Failed to make request").WithDebugInfo(err.Error()))
+		return nil, err
+	}
+
+	// add headers to the request
+	apiKey := os.Getenv(chatModel.ApiAuthKey)
+	authHeaderName := chatModel.ApiAuthHeader
+	if authHeaderName != "" {
+		req.Header.Set(authHeaderName, apiKey)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// set the streaming flag
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Connection", "keep-alive")
+
+	// create the http client and send the request
+	client := &http.Client{
+		Timeout: 5 * time.Minute,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		RespondWithAPIError(w, ErrInternalUnexpected.WithDetail("Failed to create chat completion stream").WithDebugInfo(err.Error()))
+		return nil, err
+	}
+
+	ioreader := bufio.NewReader(resp.Body)
+
+	// read the response body
+	defer resp.Body.Close()
+	// loop over the response body and print data
+
+	setSSEHeader(w)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		RespondWithAPIError(w, APIError{
+			HTTPCode: http.StatusInternalServerError,
+			Code:     "STREAM_UNSUPPORTED",
+			Message:  "Streaming unsupported by client",
+		})
+		return nil, err
+	}
+
+	var answer string
+	var answer_id string
+
+	if regenerate {
+		answer_id = chatUuid
+	}
+
+	count := 0
+	for {
+		count++
+		// prevent infinite loop
+		if count > 10000 {
+			break
+		}
+		line, err := ioreader.ReadBytes('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				fmt.Println("End of stream reached")
+				break // Exit loop if end of stream
+			}
+			return nil, err
+		}
+		var streamResp OllamaResponse
+		err = json.Unmarshal(line, &streamResp)
+		if err != nil {
+			return nil, err
+		}
+		answer += strings.ReplaceAll(streamResp.Message.Content, "<0x0A>", "\n")
+		if streamResp.Done {
+			// stream.isFinished = true
+			fmt.Println("DONE break")
+			data, _ := json.Marshal(constructChatCompletionStreamReponse(answer_id, answer))
+			fmt.Fprintf(w, "data: %v\n\n", string(data))
+			flusher.Flush()
+			break
+		}
+		if answer_id == "" {
+			answer_id = NewUUID()
+		}
+
+		if len(answer) < 200 || len(answer)%2 == 0 {
+			data, _ := json.Marshal(constructChatCompletionStreamReponse(answer_id, answer))
+			fmt.Fprintf(w, "data: %v\n\n", string(data))
+			flusher.Flush()
+		}
+	}
+
+	return &models.LLMAnswer{
+		Answer:   answer,
+		AnswerId: answer_id,
+	}, nil
+}


### PR DESCRIPTION
…ate file

- Simplified `chooseChatModel` logic by removing redundant `isClaude` check.
- Removed unused `ClaudeChatModel` and `OllamaChatModel` implementations from `chat_main_handler.go`.
- Moved `OllamaChatModel` and its streaming logic to a new file `model_ollama_service.go`.
- Cleaned up unused code and improved code organization.