### PR TITLE
Add type filtering for chat snapshots and separate chatbot/snapshot e…

### DIFF
--- a/api/chat_snapshot_handler.go
+++ b/api/chat_snapshot_handler.go
@@ -96,7 +96,9 @@ func (h *ChatSnapshotHandler) ChatSnapshotMetaByUserID(w http.ResponseWriter, r 
 		RespondWithAPIError(w, apiErr)
 		return
 	}
-	chatSnapshots, err := h.service.q.ChatSnapshotMetaByUserID(r.Context(), userID)
+	// get type from query
+	typ := r.URL.Query().Get("type")
+	chatSnapshots, err := h.service.q.ChatSnapshotMetaByUserID(r.Context(), sqlc_queries.ChatSnapshotMetaByUserIDParams{UserID: userID, Typ: typ})
 
 	if err != nil {
 		apiErr := ErrInternalUnexpected

--- a/api/sqlc/queries/chat_snapshot.sql
+++ b/api/sqlc/queries/chat_snapshot.sql
@@ -35,7 +35,7 @@ SELECT * FROM chat_snapshot WHERE user_id = $1 AND uuid = $2;
 
 -- name: ChatSnapshotMetaByUserID :many
 SELECT uuid, title, summary, tags, created_at, typ 
-FROM chat_snapshot WHERE user_id = $1
+FROM chat_snapshot WHERE user_id = $1 and typ = $2
 order by created_at desc;
 
 -- name: UpdateChatSnapshotMetaByUUID :exec

--- a/api/sqlc_queries/chat_snapshot.sql.go
+++ b/api/sqlc_queries/chat_snapshot.sql.go
@@ -93,9 +93,14 @@ func (q *Queries) ChatSnapshotByUserIdAndUuid(ctx context.Context, arg ChatSnaps
 
 const chatSnapshotMetaByUserID = `-- name: ChatSnapshotMetaByUserID :many
 SELECT uuid, title, summary, tags, created_at, typ 
-FROM chat_snapshot WHERE user_id = $1
+FROM chat_snapshot WHERE user_id = $1 and typ = $2
 order by created_at desc
 `
+
+type ChatSnapshotMetaByUserIDParams struct {
+	UserID int32  `json:"userId"`
+	Typ    string `json:"typ"`
+}
 
 type ChatSnapshotMetaByUserIDRow struct {
 	Uuid      string          `json:"uuid"`
@@ -106,8 +111,8 @@ type ChatSnapshotMetaByUserIDRow struct {
 	Typ       string          `json:"typ"`
 }
 
-func (q *Queries) ChatSnapshotMetaByUserID(ctx context.Context, userID int32) ([]ChatSnapshotMetaByUserIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, chatSnapshotMetaByUserID, userID)
+func (q *Queries) ChatSnapshotMetaByUserID(ctx context.Context, arg ChatSnapshotMetaByUserIDParams) ([]ChatSnapshotMetaByUserIDRow, error) {
+	rows, err := q.db.QueryContext(ctx, chatSnapshotMetaByUserID, arg.UserID, arg.Typ)
 	if err != nil {
 		return nil, err
 	}

--- a/web/src/api/chat_snapshot.ts
+++ b/web/src/api/chat_snapshot.ts
@@ -36,7 +36,18 @@ export const fetchChatSnapshot = async (uuid: string): Promise<any> => {
 
 export const fetchSnapshotAll = async (): Promise<any> => {
   try {
-    const response = await request.get('/uuid/chat_snapshot/all')
+    const response = await request.get('/uuid/chat_snapshot/all?type=snapshot')
+    return response.data
+  }
+  catch (error) {
+    console.error(error)
+    throw error
+  }
+}
+
+export const fetchChatbotAll= async (): Promise<any> => {
+  try {
+    const response = await request.get('/uuid/chat_snapshot/all?type=chatbot')
     return response.data
   }
   catch (error) {

--- a/web/src/views/bot/all.vue
+++ b/web/src/views/bot/all.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, ref, h } from 'vue'
 import { NModal, useDialog, useMessage } from 'naive-ui'
 import Search from '../snapshot/components/Search.vue'
-import { fetchSnapshotAll, fetchSnapshotDelete } from '@/api'
+import { fetchChatbotAll, fetchSnapshotDelete } from '@/api'
 import { HoverButton, SvgIcon } from '@/components/common'
 import { generateAPIHelper, getBotPostLinks } from '@/service/snapshot'
 import { fetchAPIToken } from '@/api/token'
@@ -29,7 +29,7 @@ onMounted(async () => {
 
 
 async function refreshSnapshot() {
-  const bots: Snapshot.Snapshot[] = await fetchSnapshotAll()
+  const bots: Snapshot.Snapshot[] = await fetchChatbotAll()
   postsByYearMonth.value = getBotPostLinks(bots)
 }
 

--- a/web/src/views/chat/components/PromptGallery/index.vue
+++ b/web/src/views/chat/components/PromptGallery/index.vue
@@ -2,7 +2,7 @@
 import { ref, computed } from 'vue'
 import { NCard, NButton, NSpace, NTabs, NTabPane } from 'naive-ui'
 import { usePromptStore } from '@/store/modules'
-import { fetchChatSnapshot, fetchSnapshotAll } from '@/api'
+import { fetchChatbotAll, fetchChatSnapshot } from '@/api'
 import { useQuery } from '@tanstack/vue-query'
 import PromptCards from './PromptCards.vue'
 import { SvgIcon } from '@/components/common'
@@ -19,7 +19,7 @@ const promptStore = usePromptStore()
 // Fetch bots data
 const { data: bots } = useQuery({
         queryKey: ['bots'],
-        queryFn: async () => await fetchSnapshotAll(),
+        queryFn: async () => await fetchChatbotAll(),
 })
 
 interface Bot {


### PR DESCRIPTION
…ndpoints

- Updated `ChatSnapshotMetaByUserID` to filter by `type` in SQL query and handler.
- Added `fetchChatbotAll` API function for chatbot-specific snapshots.
- Modified frontend to use `fetchChatbotAll` for chatbot-related views.
- Ensured type parameter is passed in API calls for proper filtering.