### PR TITLE
feat: add new chat button in mobile header and refactor header component

### DIFF
--- a/web/src/views/chat/components/Conversation.vue
+++ b/web/src/views/chat/components/Conversation.vue
@@ -8,12 +8,12 @@ import html2canvas from 'html2canvas'
 import { type OnSelect } from 'naive-ui/es/auto-complete/src/interface'
 import { useScroll } from '@/views/chat/hooks/useScroll'
 import { useChat } from '@/views/chat/hooks/useChat'
-import HeaderComponent from '@/views/chat/components/Header/index.vue'
+import HeaderMobile from '@/views/chat/components/HeaderMobile/index.vue'
 import SessionConfig from '@/views/chat/components/Session/SessionConfig.vue'
-import { createChatBot, createChatSnapshot, deleteChatMessage, fetchChatStream } from '@/api'
+import { createChatBot, createChatSnapshot, deleteChatMessage, fetchChatStream, getChatSessionDefault } from '@/api'
 import { HoverButton, SvgIcon } from '@/components/common'
 import { useBasicLayout } from '@/hooks/useBasicLayout'
-import { useChatStore, usePromptStore } from '@/store'
+import { useAppStore, useChatStore, usePromptStore } from '@/store'
 import { t } from '@/locales'
 import { genTempDownloadLink } from '@/utils/download'
 import { nowISO } from '@/utils/date'
@@ -56,6 +56,27 @@ const showModal = ref<boolean>(false)
 const snapshotLoading = ref<boolean>(false)
 const botLoading = ref<boolean>(false)
 
+const appStore = useAppStore()
+
+
+async function handleAdd() {
+  const new_chat_text = t('chat.new')
+  //   //
+  //   // {
+  //   "uuid": "ff511942-43b4-4ebd-9fe8-f2ca405605ac",
+  //   "isEdit": false,
+  //   "title": "try improve code and",
+  //   "maxLength": 10,
+  //   "temperature": 1,
+  //   "topP": 1,
+  //   "maxTokens": 512,
+  //   "debug": false
+  // }//
+  const default_model_parameters = await getChatSessionDefault(new_chat_text)
+  await chatStore.addChatSession(default_model_parameters)
+  if (isMobile.value)
+    appStore.setSiderCollapsed(true)
+}
 
 // 添加PromptStore
 const promptStore = usePromptStore()
@@ -560,7 +581,7 @@ const handleUsePrompt = (_: string, value: string): void => {
       <UploadModal :sessionUuid="sessionUuid" :showUploadModal="showUploadModal"
         @update:showUploadModal="showUploadModal = $event" />
     </div>
-    <HeaderComponent v-if="isMobile" @export="handleExport" @snapshot="handleSnapshot" @toggle="showModal = true" />
+    <HeaderMobile v-if="isMobile" @add-chat="handleAdd" @snapshot="handleSnapshot" @toggle="showModal = true" />
     <main class="flex-1 overflow-hidden">
       <NModal ref="sessionConfigModal" v-model:show="showModal" :title="$t('chat.sessionConfig')" preset="dialog">
         <SessionConfig id="session-config" ref="sessionConfig" :uuid="sessionUuid" />

--- a/web/src/views/chat/components/HeaderMobile/index.vue
+++ b/web/src/views/chat/components/HeaderMobile/index.vue
@@ -5,8 +5,8 @@ import { useAppStore, useChatStore } from '@/store'
 
 interface Emit {
   (ev: 'snapshot'): void
-  (ev: 'export'): void
   (ev: 'toggle'): void
+  (ev: 'addChat'): void
 }
 
 const emit = defineEmits<Emit>()
@@ -27,10 +27,6 @@ function onScrollToTop() {
     nextTick(() => scrollRef.scrollTop = 0)
 }
 
-function handleExport() {
-  emit('export')
-}
-
 function toggle() {
   emit('toggle')
 }
@@ -38,44 +34,43 @@ function toggle() {
 function handleSnapshot() {
   emit('snapshot')
 }
+
+function handleAdd() {
+  emit('addChat')
+}
 </script>
 
 <template>
   <header
-    class="sticky top-0 left-0 right-0 z-30 border-b dark:border-neutral-800 bg-white/80 dark:bg-black/20 backdrop-blur"
-  >
+    class="sticky top-0 left-0 right-0 z-30 border-b dark:border-neutral-800 bg-white/80 dark:bg-black/20 backdrop-blur">
     <div class="relative flex items-center justify-between min-w-0 overflow-hidden h-14">
       <div class="flex items-center">
-        <button
-          class="flex items-center justify-center w-11 h-11"
-          @click="handleUpdateCollapsed"
-        >
+        <button class="flex items-center justify-center w-11 h-11" @click="handleUpdateCollapsed">
           <SvgIcon v-if="collapsed" class="text-2xl" icon="ri:align-justify" />
           <SvgIcon v-else class="text-2xl" icon="ri:align-right" />
         </button>
       </div>
-      <h1
-        class="flex-1 px-4 pr-6 overflow-hidden cursor-pointer select-none text-ellipsis whitespace-nowrap"
-        @dblclick="onScrollToTop"
-      >
+      <h1 class="flex-1 px-4 pr-6 overflow-hidden cursor-pointer select-none text-ellipsis whitespace-nowrap"
+        @dblclick="onScrollToTop">
         {{ currentChatSession?.title ?? '' }}
       </h1>
       <div class="flex items-center space-x-2">
-        <HoverButton :tooltip="$t('chat.adjustParameters')" @click="toggle">
-          <span class="text-xl text-[#4b9e5f]">
-            <SvgIcon icon="teenyicons:adjust-horizontal-solid" />
-          </span>
-        </HoverButton>
-        <HoverButton :tooltip="$t('chat.exportImage')" @click="handleExport">
-          <span class="text-xl text-[#4b9e5f] dark:text-white">
-            <SvgIcon icon="ri:download-2-line" />
-          </span>
-        </HoverButton>
         <HoverButton :tooltip="$t('chat.chatSnapshot')" @click="handleSnapshot">
           <span class="text-xl text-[#4b9e5f] dark:text-white">
             <SvgIcon icon="ic:twotone-ios-share" />
           </span>
         </HoverButton>
+        <HoverButton :tooltip="$t('chat.adjustParameters')" @click="toggle">
+          <span class="text-xl text-[#4b9e5f]">
+            <SvgIcon icon="teenyicons:adjust-horizontal-solid" />
+          </span>
+        </HoverButton>
+        <HoverButton :tooltip="$t('chat.new')" @click="handleAdd">
+          <span class="text-xl text-[#4b9e5f]">
+            <SvgIcon icon="material-symbols:add-circle-outline" />
+          </span>
+        </HoverButton>
+   
       </div>
     </div>
   </header>


### PR DESCRIPTION
```
feat: add new chat button in mobile header and refactor header component

- Rename Header to HeaderMobile and update imports
- Add handleAdd function to create new chat sessions with default parameters
- Replace export button with new chat button in mobile header
- Include appStore for mobile sider collapse state
```