### PR TITLE
"Refactor streaming to send deltas instead of full content"

### DIFF
--- a/api/llm/gemini/gemini.go
+++ b/api/llm/gemini/gemini.go
@@ -128,6 +128,30 @@ func ParseRespLine(line []byte, answer string) string {
 	return answer
 }
 
+// ParseRespLineDelta extracts only the delta content from a response line without accumulating
+func ParseRespLineDelta(line []byte) string {
+	var resp ResponseBody
+	if err := json.Unmarshal(line, &resp); err != nil {
+		fmt.Println("Failed to parse request body:", err)
+		return ""
+	}
+
+	var delta string
+	for _, candidate := range resp.Candidates {
+		for idx, part := range candidate.Content.Parts {
+			if idx > 0 {
+				delta += "\n\n"
+			}
+			if part.Thought {
+				delta += ("<think>" + part.Text + "<think>")
+			} else {
+				delta += part.Text
+			}
+		}
+	}
+	return delta
+}
+
 func SupportedMimeTypes() mapset.Set[string] {
 	return mapset.NewSet(
 		"image/png",

--- a/api/model_gemini_service.go
+++ b/api/model_gemini_service.go
@@ -207,10 +207,14 @@ func (m *GeminiChatModel) handleStreamResponse(w http.ResponseWriter, req *http.
 
 		line = bytes.TrimPrefix(line, headerData)
 		if len(line) > 0 {
-			answer = gemini.ParseRespLine(line, answer)
-			data, _ := json.Marshal(constructChatCompletionStreamReponse(answerID, answer))
-			fmt.Fprintf(w, "data: %v\n\n", string(data))
-			flusher.Flush()
+			delta := gemini.ParseRespLineDelta(line)
+			answer += delta // Accumulate delta for final answer storage
+			// Send only the delta content
+			if len(delta) > 0 {
+				data, _ := json.Marshal(constructChatCompletionStreamReponse(answerID, delta))
+				fmt.Fprintf(w, "data: %v\n\n", string(data))
+				flusher.Flush()
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit:
1. Adds ParseRespLineDelta for Gemini to extract delta content
2. Modifies all model services (Claude3, Gemini, Ollama, OpenAI) to stream deltas
3. Updates frontend to properly handle and append delta chunks
4. Removes redundant full content sends at stream end
5. Improves streaming efficiency by reducing data transfer