### PR TITLE
Refactor model selection to use api_type from database

### DIFF
--- a/api/chat_model_handler.go
+++ b/api/chat_model_handler.go
@@ -123,6 +123,7 @@ func (h *ChatModelHandler) CreateChatModel(w http.ResponseWriter, r *http.Reques
 		ApiAuthHeader          string `json:"apiAuthHeader"`
 		ApiAuthKey             string `json:"apiAuthKey"`
 		EnablePerModeRatelimit bool   `json:"enablePerModeRatelimit"`
+		ApiType                string `json:"apiType"`
 	}
 
 	err = json.NewDecoder(r.Body).Decode(&input)
@@ -131,6 +132,12 @@ func (h *ChatModelHandler) CreateChatModel(w http.ResponseWriter, r *http.Reques
 		apiErr.DebugInfo = err.Error()
 		RespondWithAPIError(w, apiErr)
 		return
+	}
+
+	// Set default api_type if not provided
+	apiType := input.ApiType
+	if apiType == "" {
+		apiType = "openai" // default api type
 	}
 
 	ChatModel, err := h.db.CreateChatModel(r.Context(), sqlc_queries.CreateChatModelParams{
@@ -142,6 +149,11 @@ func (h *ChatModelHandler) CreateChatModel(w http.ResponseWriter, r *http.Reques
 		ApiAuthKey:             input.ApiAuthKey,
 		UserID:                 userID,
 		EnablePerModeRatelimit: input.EnablePerModeRatelimit,
+		MaxToken:               4096,  // default max token
+		DefaultToken:           2048,  // default token
+		OrderNumber:            0,     // default order
+		HttpTimeOut:            120,   // default timeout
+		ApiType:               apiType,
 	})
 
 	if err != nil {
@@ -175,18 +187,19 @@ func (h *ChatModelHandler) UpdateChatModel(w http.ResponseWriter, r *http.Reques
 	}
 
 	var input struct {
-		Name                   string
-		Label                  string
-		IsDefault              bool
-		URL                    string
-		ApiAuthHeader          string
-		ApiAuthKey             string
-		EnablePerModeRatelimit bool
-		OrderNumber            int32
-		DefaultToken           int32
-		MaxToken               int32
-		HttpTimeOut            int32
-		IsEnable               bool
+		Name                   string `json:"name"`
+		Label                  string `json:"label"`
+		IsDefault              bool   `json:"isDefault"`
+		URL                    string `json:"url"`
+		ApiAuthHeader          string `json:"apiAuthHeader"`
+		ApiAuthKey             string `json:"apiAuthKey"`
+		EnablePerModeRatelimit bool   `json:"enablePerModeRatelimit"`
+		OrderNumber            int32  `json:"orderNumber"`
+		DefaultToken           int32  `json:"defaultToken"`
+		MaxToken               int32  `json:"maxToken"`
+		HttpTimeOut            int32  `json:"httpTimeOut"`
+		IsEnable               bool   `json:"isEnable"`
+		ApiType                string `json:"apiType"`
 	}
 	err = json.NewDecoder(r.Body).Decode(&input)
 	if err != nil {
@@ -194,6 +207,12 @@ func (h *ChatModelHandler) UpdateChatModel(w http.ResponseWriter, r *http.Reques
 		apiErr.DebugInfo = err.Error()
 		RespondWithAPIError(w, apiErr)
 		return
+	}
+
+	// Set default api_type if not provided
+	apiType := input.ApiType
+	if apiType == "" {
+		apiType = "openai" // default api type
 	}
 
 	ChatModel, err := h.db.UpdateChatModel(r.Context(), sqlc_queries.UpdateChatModelParams{
@@ -211,6 +230,7 @@ func (h *ChatModelHandler) UpdateChatModel(w http.ResponseWriter, r *http.Reques
 		MaxToken:               input.MaxToken,
 		HttpTimeOut:            input.HttpTimeOut,
 		IsEnable:               input.IsEnable,
+		ApiType:               apiType,
 	})
 
 	if err != nil {

--- a/api/sqlc/queries/chat_model.sql
+++ b/api/sqlc/queries/chat_model.sql
@@ -13,13 +13,13 @@ SELECT * FROM chat_model WHERE id = $1;
 SELECT * FROM chat_model WHERE name = $1;
 
 -- name: CreateChatModel :one
-INSERT INTO chat_model (name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+INSERT INTO chat_model (name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, api_type )
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 RETURNING *;
 
 -- name: UpdateChatModel :one
 UPDATE chat_model SET name = $2, label = $3, is_default = $4, url = $5, api_auth_header = $6, api_auth_key = $7, enable_per_mode_ratelimit = $9,
-max_token = $10, default_token = $11, order_number = $12, http_time_out = $13, is_enable = $14
+max_token = $10, default_token = $11, order_number = $12, http_time_out = $13, is_enable = $14, api_type = $15
 WHERE id = $1 and user_id = $8
 RETURNING *;
 

--- a/api/sqlc/schema.sql
+++ b/api/sqlc/schema.sql
@@ -37,6 +37,8 @@ ALTER TABLE chat_model ADD COLUMN IF NOT EXISTS default_token INTEGER NOT NULL d
 ALTER TABLE chat_model ADD COLUMN IF NOT EXISTS order_number INTEGER NOT NULL default 1;
 ALTER TABLE chat_model ADD COLUMN IF NOT EXISTS http_time_out INTEGER NOT NULL default 120;
 ALTER TABLE chat_model ADD COLUMN IF NOT EXISTS is_enable BOOLEAN DEFAULT true NOT NULL;
+ALTER TABLE chat_model ADD COLUMN IF NOT EXISTS api_type VARCHAR(50) NOT NULL DEFAULT 'openai';
+
 
 
 INSERT INTO chat_model(name, label, is_default, url, api_auth_header, api_auth_key, max_token, default_token, order_number)
@@ -58,6 +60,13 @@ UPDATE chat_model SET enable_per_mode_ratelimit = true WHERE name = 'gpt-4-32k';
 DELETE FROM chat_model where name = 'claude-v1';
 DELETE FROM chat_model where name = 'claude-v1-100k';
 DELETE FROM chat_model where name = 'claude-instant-v1';
+
+-- Update existing records with appropriate api_type values
+UPDATE chat_model SET api_type = 'openai' WHERE name LIKE 'gpt-%' OR name LIKE 'text-davinci-%' OR name LIKE 'deepseek-%';
+UPDATE chat_model SET api_type = 'claude' WHERE name LIKE 'claude-%';
+UPDATE chat_model SET api_type = 'gemini' WHERE name LIKE 'gemini-%';
+UPDATE chat_model SET api_type = 'ollama' WHERE name LIKE 'ollama-%';
+UPDATE chat_model SET api_type = 'custom' WHERE name LIKE 'custom-%' OR name IN ('echo', 'debug');
 -- create index on name
 CREATE INDEX IF NOT EXISTS jwt_secrets_name_idx ON jwt_secrets (name);
 

--- a/api/sqlc_queries/chat_model.sql.go
+++ b/api/sqlc_queries/chat_model.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const chatModelByID = `-- name: ChatModelByID :one
-SELECT id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable FROM chat_model WHERE id = $1
+SELECT id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable, api_type FROM chat_model WHERE id = $1
 `
 
 func (q *Queries) ChatModelByID(ctx context.Context, id int32) (ChatModel, error) {
@@ -31,12 +31,13 @@ func (q *Queries) ChatModelByID(ctx context.Context, id int32) (ChatModel, error
 		&i.OrderNumber,
 		&i.HttpTimeOut,
 		&i.IsEnable,
+		&i.ApiType,
 	)
 	return i, err
 }
 
 const chatModelByName = `-- name: ChatModelByName :one
-SELECT id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable FROM chat_model WHERE name = $1
+SELECT id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable, api_type FROM chat_model WHERE name = $1
 `
 
 func (q *Queries) ChatModelByName(ctx context.Context, name string) (ChatModel, error) {
@@ -57,14 +58,15 @@ func (q *Queries) ChatModelByName(ctx context.Context, name string) (ChatModel, 
 		&i.OrderNumber,
 		&i.HttpTimeOut,
 		&i.IsEnable,
+		&i.ApiType,
 	)
 	return i, err
 }
 
 const createChatModel = `-- name: CreateChatModel :one
-INSERT INTO chat_model (name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-RETURNING id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable
+INSERT INTO chat_model (name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, api_type )
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+RETURNING id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable, api_type
 `
 
 type CreateChatModelParams struct {
@@ -80,6 +82,7 @@ type CreateChatModelParams struct {
 	DefaultToken           int32  `json:"defaultToken"`
 	OrderNumber            int32  `json:"orderNumber"`
 	HttpTimeOut            int32  `json:"httpTimeOut"`
+	ApiType                string `json:"apiType"`
 }
 
 func (q *Queries) CreateChatModel(ctx context.Context, arg CreateChatModelParams) (ChatModel, error) {
@@ -96,6 +99,7 @@ func (q *Queries) CreateChatModel(ctx context.Context, arg CreateChatModelParams
 		arg.DefaultToken,
 		arg.OrderNumber,
 		arg.HttpTimeOut,
+		arg.ApiType,
 	)
 	var i ChatModel
 	err := row.Scan(
@@ -113,6 +117,7 @@ func (q *Queries) CreateChatModel(ctx context.Context, arg CreateChatModelParams
 		&i.OrderNumber,
 		&i.HttpTimeOut,
 		&i.IsEnable,
+		&i.ApiType,
 	)
 	return i, err
 }
@@ -132,7 +137,7 @@ func (q *Queries) DeleteChatModel(ctx context.Context, arg DeleteChatModelParams
 }
 
 const getDefaultChatModel = `-- name: GetDefaultChatModel :one
-SELECT id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable FROM chat_model WHERE is_default = true
+SELECT id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable, api_type FROM chat_model WHERE is_default = true
 and user_id in (select id from auth_user where is_superuser = true)
 ORDER BY order_number, id
 LIMIT 1
@@ -156,12 +161,13 @@ func (q *Queries) GetDefaultChatModel(ctx context.Context) (ChatModel, error) {
 		&i.OrderNumber,
 		&i.HttpTimeOut,
 		&i.IsEnable,
+		&i.ApiType,
 	)
 	return i, err
 }
 
 const listChatModels = `-- name: ListChatModels :many
-SELECT id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable FROM chat_model ORDER BY order_number
+SELECT id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable, api_type FROM chat_model ORDER BY order_number
 `
 
 func (q *Queries) ListChatModels(ctx context.Context) ([]ChatModel, error) {
@@ -188,6 +194,7 @@ func (q *Queries) ListChatModels(ctx context.Context) ([]ChatModel, error) {
 			&i.OrderNumber,
 			&i.HttpTimeOut,
 			&i.IsEnable,
+			&i.ApiType,
 		); err != nil {
 			return nil, err
 		}
@@ -203,7 +210,7 @@ func (q *Queries) ListChatModels(ctx context.Context) ([]ChatModel, error) {
 }
 
 const listSystemChatModels = `-- name: ListSystemChatModels :many
-SELECT id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable FROM chat_model
+SELECT id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable, api_type FROM chat_model
 where user_id in (select id from auth_user where is_superuser = true)
 ORDER BY order_number, id desc
 `
@@ -232,6 +239,7 @@ func (q *Queries) ListSystemChatModels(ctx context.Context) ([]ChatModel, error)
 			&i.OrderNumber,
 			&i.HttpTimeOut,
 			&i.IsEnable,
+			&i.ApiType,
 		); err != nil {
 			return nil, err
 		}
@@ -248,9 +256,9 @@ func (q *Queries) ListSystemChatModels(ctx context.Context) ([]ChatModel, error)
 
 const updateChatModel = `-- name: UpdateChatModel :one
 UPDATE chat_model SET name = $2, label = $3, is_default = $4, url = $5, api_auth_header = $6, api_auth_key = $7, enable_per_mode_ratelimit = $9,
-max_token = $10, default_token = $11, order_number = $12, http_time_out = $13, is_enable = $14
+max_token = $10, default_token = $11, order_number = $12, http_time_out = $13, is_enable = $14, api_type = $15
 WHERE id = $1 and user_id = $8
-RETURNING id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable
+RETURNING id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable, api_type
 `
 
 type UpdateChatModelParams struct {
@@ -268,6 +276,7 @@ type UpdateChatModelParams struct {
 	OrderNumber            int32  `json:"orderNumber"`
 	HttpTimeOut            int32  `json:"httpTimeOut"`
 	IsEnable               bool   `json:"isEnable"`
+	ApiType                string `json:"apiType"`
 }
 
 func (q *Queries) UpdateChatModel(ctx context.Context, arg UpdateChatModelParams) (ChatModel, error) {
@@ -286,6 +295,7 @@ func (q *Queries) UpdateChatModel(ctx context.Context, arg UpdateChatModelParams
 		arg.OrderNumber,
 		arg.HttpTimeOut,
 		arg.IsEnable,
+		arg.ApiType,
 	)
 	var i ChatModel
 	err := row.Scan(
@@ -303,6 +313,7 @@ func (q *Queries) UpdateChatModel(ctx context.Context, arg UpdateChatModelParams
 		&i.OrderNumber,
 		&i.HttpTimeOut,
 		&i.IsEnable,
+		&i.ApiType,
 	)
 	return i, err
 }
@@ -310,7 +321,7 @@ func (q *Queries) UpdateChatModel(ctx context.Context, arg UpdateChatModelParams
 const updateChatModelKey = `-- name: UpdateChatModelKey :one
 UPDATE chat_model SET api_auth_key = $2
 WHERE id = $1
-RETURNING id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable
+RETURNING id, name, label, is_default, url, api_auth_header, api_auth_key, user_id, enable_per_mode_ratelimit, max_token, default_token, order_number, http_time_out, is_enable, api_type
 `
 
 type UpdateChatModelKeyParams struct {
@@ -336,6 +347,7 @@ func (q *Queries) UpdateChatModelKey(ctx context.Context, arg UpdateChatModelKey
 		&i.OrderNumber,
 		&i.HttpTimeOut,
 		&i.IsEnable,
+		&i.ApiType,
 	)
 	return i, err
 }

--- a/api/sqlc_queries/models.go
+++ b/api/sqlc_queries/models.go
@@ -111,6 +111,7 @@ type ChatModel struct {
 	OrderNumber            int32  `json:"orderNumber"`
 	HttpTimeOut            int32  `json:"httpTimeOut"`
 	IsEnable               bool   `json:"isEnable"`
+	ApiType                string `json:"apiType"`
 }
 
 type ChatPrompt struct {

--- a/web/src/components/admin/ModelCard.vue
+++ b/web/src/components/admin/ModelCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { NButton, NCard, NModal, NForm, NFormItem, NInput, NSwitch, useMessage, NBadge, useDialog } from 'naive-ui'
+import { NButton, NCard, NModal, NForm, NFormItem, NInput, NSwitch, NSelect, useMessage, NBadge, useDialog } from 'naive-ui'
 import { t  } from '@/locales'
 import { useMutation, useQueryClient } from '@tanstack/vue-query'
 import { updateChatModel, deleteChatModel } from '@/api'
@@ -15,6 +15,15 @@ const ms_ui = useMessage()
 const dialog = useDialog()
 const dialogVisible = ref(false)
 const editData = ref({ ...props.model })
+
+// API Type options
+const apiTypeOptions = [
+  { label: 'OpenAI', value: 'openai' },
+  { label: 'Claude', value: 'claude' },
+  { label: 'Gemini', value: 'gemini' },
+  { label: 'Ollama', value: 'ollama' },
+  { label: 'Custom', value: 'custom' }
+]
 
 const chatModelMutation = useMutation({
   mutationFn: (variables: { id: number, data: any }) => updateChatModel(variables.id, variables.data),
@@ -77,6 +86,7 @@ function copyJson() {
   const dataToCopy = {
     name: editData.value.name,
     label: editData.value.label,
+    apiType: editData.value.apiType,
     url: editData.value.url,
     apiAuthHeader: editData.value.apiAuthHeader,
     apiAuthKey: editData.value.apiAuthKey,
@@ -111,6 +121,9 @@ function copyJson() {
             <NBadge v-if="model.isDefault" type="success" :value="t('admin.chat_model.default')" size="large" class="font-bold" />
           </div>
           <p class="text-gray-500" :class="{ 'text-green-600': model.isDefault }">{{ model.label }}</p>
+          <div class="flex items-center gap-2 mt-1">
+            <NBadge type="info" :value="model.apiType || 'openai'" />
+          </div>
         </div>
         <NSwitch :value="model.isEnable" @update:value="handleEnableToggle" @click.stop />
       </div>
@@ -124,6 +137,9 @@ function copyJson() {
           </NFormItem>
           <NFormItem :label="t('admin.chat_model.label')">
             <NInput v-model:value="editData.label" />
+          </NFormItem>
+          <NFormItem :label="t('admin.chat_model.apiType')">
+            <NSelect v-model:value="editData.apiType" :options="apiTypeOptions" />
           </NFormItem>
           <NFormItem :label="t('admin.chat_model.url')">
             <NInput v-model:value="editData.url" />

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -6,6 +6,7 @@
             "actions": "Actions",
             "apiAuthHeader": "Auth Header key",
             "apiAuthKey": "API KEY corresponding to the environment variable",
+            "apiType": "API Type",
             "clear_form": "Clear Form",
             "copy": "Copy",
             "copy_success": "Copied successfully",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -204,6 +204,7 @@
       "isDefault": "是否默认",
       "apiAuthHeader": "AuthHeader",
       "apiAuthKey": "API密钥环境变量",
+      "apiType": "API类型",
       "actions": "操作",
       "url": "访问接口(完整URL路径)",
       "enablePerModeRatelimit": "是否单独流控",

--- a/web/src/types/chat-models.ts
+++ b/web/src/types/chat-models.ts
@@ -6,7 +6,7 @@ export interface ChatModel {
   isDefault: boolean
   orderNumber: number
   lastUsageTime: string
-  provider: string
+  apiType: string
   maxTokens?: number
   costPer1kTokens?: number
   description?: string
@@ -15,7 +15,7 @@ export interface ChatModel {
 export interface CreateChatModelRequest {
   name: string
   label: string
-  provider: string
+  apiType: string
   isEnable?: boolean
   isDefault?: boolean
   orderNumber?: number
@@ -27,7 +27,7 @@ export interface CreateChatModelRequest {
 export interface UpdateChatModelRequest {
   name?: string
   label?: string
-  provider?: string
+  apiType?: string
   isEnable?: boolean
   isDefault?: boolean
   orderNumber?: number

--- a/web/src/views/admin/model/AddModelForm.vue
+++ b/web/src/views/admin/model/AddModelForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { NButton, NForm, NFormItem, NInput, NSwitch, useMessage } from 'naive-ui'
+import { NButton, NForm, NFormItem, NInput, NSwitch, NSelect, useMessage } from 'naive-ui'
 import { createChatModel } from '@/api'
 import { useMutation, useQueryClient } from '@tanstack/vue-query'
 
@@ -21,10 +21,20 @@ const defaultFormData = {
   isEnable: true,
   orderNumber: 0,
   defaultToken: 0,
-  maxToken: 0
+  maxToken: 0,
+  apiType: 'openai'
 }
 
 const formData = ref<Chat.ChatModel>({ ...defaultFormData })
+
+// API Type options
+const apiTypeOptions = [
+  { label: 'OpenAI', value: 'openai' },
+  { label: 'Claude', value: 'claude' },
+  { label: 'Gemini', value: 'gemini' },
+  { label: 'Ollama', value: 'ollama' },
+  { label: 'Custom', value: 'custom' }
+]
 
 function clearForm() {
   formData.value = { ...defaultFormData }
@@ -100,6 +110,9 @@ async function addRow() {
       </NFormItem>
       <NFormItem path="label" :label="$t('admin.chat_model.label')">
         <NInput v-model:value="formData.label" />
+      </NFormItem>
+      <NFormItem path="apiType" :label="$t('admin.chat_model.apiType')">
+        <NSelect v-model:value="formData.apiType" :options="apiTypeOptions" />
       </NFormItem>
       <NFormItem path="url" :label="$t('admin.chat_model.url')">
         <NInput v-model:value="formData.url" />


### PR DESCRIPTION
- Added api_type field to chat_model table with default values
- Updated model selection logic to use api_type instead of string prefixes
- Added api_type support in admin UI and API endpoints
- Grouped models by api_type in model selector dropdown
- Set default api_type values for existing models