### PR TITLE
"Reset suggested questions on regenerate and UI improvements"

### DIFF
--- a/api/sqlc/queries/chat_message.sql
+++ b/api/sqlc/queries/chat_message.sql
@@ -118,7 +118,7 @@ ORDER BY created_at;
 
 -- name: UpdateChatMessageContent :exec
 UPDATE chat_message
-SET content = $2, updated_at = now(), token_count = $3
+SET content = $2, updated_at = now(), token_count = $3, suggested_questions = '[]'
 WHERE uuid = $1 ;
 
 -- name: UpdateChatMessageSuggestions :one

--- a/api/sqlc_queries/chat_message.sql.go
+++ b/api/sqlc_queries/chat_message.sql.go
@@ -813,7 +813,7 @@ func (q *Queries) UpdateChatMessageByUUID(ctx context.Context, arg UpdateChatMes
 
 const updateChatMessageContent = `-- name: UpdateChatMessageContent :exec
 UPDATE chat_message
-SET content = $2, updated_at = now(), token_count = $3
+SET content = $2, updated_at = now(), token_count = $3, suggested_questions = '[]'
 WHERE uuid = $1
 `
 

--- a/web/src/views/chat/components/Message/index.vue
+++ b/web/src/views/chat/components/Message/index.vue
@@ -124,12 +124,7 @@ function handleNextSuggestionsBatch() {
               :disabled="pining" @click="emit('togglePin')">
               <SvgIcon :icon="isPin ? 'ri:unpin-line' : 'ri:pushpin-line'" />
             </button>
-            <!-- testid="chat-message-regenerate" not ok, something like testclass -->
-            <button v-if="!isPrompt"
-              class="chat-message-regenerate mb-2 transition text-neutral-300 hover:text-neutral-800 dark:hover:text-neutral-300"
-              @click="handleRegenerate">
-              <SvgIcon icon="ri:restart-line" />
-            </button>
+
 
           </div>
 
@@ -149,6 +144,12 @@ function handleNextSuggestionsBatch() {
               @click="handleEdit">
               <SvgIcon icon="ri:edit-line" />
             </HoverButton>
+            <!-- testid="chat-message-regenerate" not ok, something like testclass -->
+            <HoverButton :tooltip="$t('common.regenerate')"
+              class="transition text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-300"
+              @click="handleRegenerate">
+              <SvgIcon icon="ri:restart-line" />
+            </HoverButton>
             <HoverButton :tooltip="$t('chat.copy')"
               class="transition text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-300"
               @click="handleCopy">
@@ -157,15 +158,13 @@ function handleNextSuggestionsBatch() {
 
           </div>
         </div>
-        <SuggestedQuestions v-if="!inversion && exploreMode && !loading && (suggestedQuestionsLoading || (suggestedQuestions && suggestedQuestions.length > 0))" 
+        <SuggestedQuestions
+          v-if="!inversion && exploreMode && !loading && (suggestedQuestionsLoading || (suggestedQuestions && suggestedQuestions.length > 0))"
           :questions="suggestedQuestions || []"
           :loading="suggestedQuestionsLoading && (!suggestedQuestions || suggestedQuestions.length === 0)"
-          :batches="suggestedQuestionsBatches"
-          :currentBatch="currentSuggestedQuestionsBatch"
-          :generating="suggestedQuestionsGenerating"
-          @useQuestion="handleUseQuestion"
-          @generateMore="handleGenerateMoreSuggestions"
-          @previousBatch="handlePreviousSuggestionsBatch"
+          :batches="suggestedQuestionsBatches" :currentBatch="currentSuggestedQuestionsBatch"
+          :generating="suggestedQuestionsGenerating" @useQuestion="handleUseQuestion"
+          @generateMore="handleGenerateMoreSuggestions" @previousBatch="handlePreviousSuggestionsBatch"
           @nextBatch="handleNextSuggestionsBatch" />
       </div>
     </div>

--- a/web/src/views/chat/components/Message/index.vue
+++ b/web/src/views/chat/components/Message/index.vue
@@ -146,7 +146,7 @@ function handleNextSuggestionsBatch() {
             </HoverButton>
             <!-- testid="chat-message-regenerate" not ok, something like testclass -->
             <HoverButton :tooltip="$t('common.regenerate')"
-              class="transition text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-300"
+              class="chat-message-regenerate transition text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-300"
               @click="handleRegenerate">
               <SvgIcon icon="ri:restart-line" />
             </HoverButton>

--- a/web/src/views/chat/composables/useRegenerate.ts
+++ b/web/src/views/chat/composables/useRegenerate.ts
@@ -38,6 +38,11 @@ export function useRegenerate(sessionUuid: string) {
         inversion: false,
         error: false,
         loading: true,
+        suggestedQuestions: undefined,
+        suggestedQuestionsLoading: false,
+        suggestedQuestionsBatches: undefined,
+        currentSuggestedQuestionsBatch: undefined,
+        suggestedQuestionsGenerating: false,
       })
     }
 
@@ -61,6 +66,11 @@ export function useRegenerate(sessionUuid: string) {
         inversion: false,
         error: false,
         loading: true,
+        suggestedQuestions: undefined,
+        suggestedQuestionsLoading: false,
+        suggestedQuestionsBatches: undefined,
+        currentSuggestedQuestionsBatch: undefined,
+        suggestedQuestionsGenerating: false,
       })
     } else {
       addChat(sessionUuid, {
@@ -70,6 +80,11 @@ export function useRegenerate(sessionUuid: string) {
         loading: true,
         inversion: false,
         error: false,
+        suggestedQuestions: undefined,
+        suggestedQuestionsLoading: false,
+        suggestedQuestionsBatches: undefined,
+        currentSuggestedQuestionsBatch: undefined,
+        suggestedQuestionsGenerating: false,
       })
     }
 


### PR DESCRIPTION
This commit:
1. Resets suggested_questions to empty array when updating message content
2. Moves regenerate button to action buttons group
3. Clears suggested questions state when regenerating messages
4. Improves UI consistency for action buttons